### PR TITLE
Move from -fg/-bg to -style

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -1,25 +1,20 @@
 # COLOUR (base16)
 
 # default statusbar colors
-set-option -g status-bg "#{{base00-hex}}"
-set-option -g status-fg "#{{base04-hex}}"
-set-option -g status-attr default
+set-option -g status-style "fg=#{{base04-hex}},bg=#{{base00-hex}}"
 
 # default window title colors
-set-window-option -g window-status-bg default
-set-window-option -g window-status-fg "#{{base04-hex}}"
+set-window-option -g window-status-style "fg=#{{base04-hex}},bg=default"
 
 # active window title colors
-set-window-option -g window-status-current-bg default
-set-window-option -g window-status-current-fg "#{{base05-hex}}"
+set-window-option -g window-status-current-style "fg=#{{base05-hex}},bg=default"
 
 # pane border
-set-option -g pane-border-fg "#{{base01-hex}}"
-set-option -g pane-active-border-fg "#{{base02-hex}}"
+set-option -g pane-border-style "fg=#{{base01-hex}}"
+set-option -g pane-active-border-style "fg=#{{base02-hex}}"
 
 # message text
-set-option -g message-bg "#{{base01-hex}}"
-set-option -g message-fg "#{{base05-hex}}"
+set-option -g message-style "fg=#{{base05-hex}},bg=#{{base01-hex}}"
 
 # pane number display
 set-option -g display-panes-active-colour "#{{base0B-hex}}"
@@ -29,4 +24,4 @@ set-option -g display-panes-colour "#{{base0A-hex}}"
 set-window-option -g clock-mode-colour "#{{base0B-hex}}"
 
 # bell
-set-window-option -g window-status-bell-style fg="#{{base01-hex}}",bg="#{{base08-hex}}"
+set-window-option -g window-status-bell-style "fg=#{{base01-hex}},bg=#{{base08-hex}}"

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -7,7 +7,7 @@ set-option -g status-style "fg=#{{base04-hex}},bg=#{{base00-hex}}"
 set-window-option -g window-status-style "fg=#{{base04-hex}},bg=default"
 
 # active window title colors
-set-window-option -g window-status-current-style "fg=#{{base05-hex}},bg=default"
+set-window-option -g window-status-current-style "fg=#{{base06-hex}},bg=default"
 
 # pane border
 set-option -g pane-border-style "fg=#{{base01-hex}}"


### PR DESCRIPTION
The `-fg`/`-bg` syntax was deprecated in tmux in 1.9, and removed entirely in the newly released 2.9.