### PR TITLE
Add copy-mode selection style

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -23,5 +23,8 @@ set-option -g display-panes-colour "#{{base0A-hex}}"
 # clock
 set-window-option -g clock-mode-colour "#{{base0B-hex}}"
 
+# copy mode highligh
+set-window-option -g mode-style "fg=#{{base04-hex}},bg=#{{base02-hex}}"
+
 # bell
 set-window-option -g window-status-bell-style "fg=#{{base01-hex}},bg=#{{base08-hex}}"


### PR DESCRIPTION
Following the [styling guideline](https://github.com/chriskempson/base16/blob/master/styling.md), selections should have base02 backgrounds. I sort of just assumed that the default foreground color should be used.