### PR TITLE
adds synth-midnight-dark colorscheme

### DIFF
--- a/colors/base16-synth-midnight-dark.conf
+++ b/colors/base16-synth-midnight-dark.conf
@@ -1,0 +1,30 @@
+# COLOUR (base16)
+
+# default statusbar colors
+set-option -g status-style "fg=#BFBBBF,bg=#141414"
+
+# default window title colors
+set-window-option -g window-status-style "fg=#BFBBBF,bg=default"
+
+# active window title colors
+set-window-option -g window-status-current-style "fg=#DAE84D,bg=default"
+
+# pane border
+set-option -g pane-border-style "fg=#141414"
+set-option -g pane-active-border-style "fg=#242424"
+
+# message text
+set-option -g message-style "fg=#DFDBDF,bg=#141414"
+
+# pane number display
+set-option -g display-panes-active-colour "#06EA61"
+set-option -g display-panes-colour "#DAE84D"
+
+# clock
+set-window-option -g clock-mode-colour "#06EA61"
+
+# copy mode highligh
+set-window-option -g mode-style "fg=#BFBBBF,bg=#242424"
+
+# bell
+set-window-option -g window-status-bell-style "fg=#141414,bg=#B53B50"


### PR DESCRIPTION
This adds a missing color scheme that is available in other base16 template repositories.