### PR TITLE
feat: distinguish active and inactive window

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -1,5 +1,9 @@
 # COLOUR (base16)
 
+# Active vs inactive window
+set-window-option -g window-active-style "bg=#{{base07-hex}},fg=#{{base04-hex}}" # active window
+set-window-option -g window-style "bg=#{{base06-hex}},fg=#{{base04-hex}}" # INactive window
+
 # default statusbar colors
 set-option -g status-style "fg=#{{base04-hex}},bg=#{{base01-hex}}"
 


### PR DESCRIPTION
Configure different colors for _active_ and _inactive_ window to highlight focus 

### Preview
![preview focused windows is light, inactives are greyed](https://user-images.githubusercontent.com/1212392/177187279-832e2d4a-9136-4212-af15-fba513d179c1.gif)

