### PR TITLE
Increase script speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ All the base16 themes are provided so you can pick and choose via
 
 - `set -g @colors-base16 'default-dark'` (the default)
 
-## Usage with [Base16-Shell][3]
+## Usage 
+
+### [Base16-Shell][3]
 
 Your base16-tmux theme can be automatically switched alongside your
 [base16-vim][4] and [base16-fzf][6] theme if you use [base16-shell][3].
@@ -45,6 +47,19 @@ Your base16-tmux theme can be automatically switched alongside your
 Follow the TPM (Tmux Plugin Manager) installation instructions above and
 your tmux theme will automatically switch when you change
 [base16-shell][3] themes.
+
+### `$BASE16_THEME_DEFAULT`
+
+[base16-shell][3] supports the environment variable
+`$BASE16_THEME_DEFAULT`. For consistency, base16-tmux also works with
+this variable. If you have `$BASE16_THEME_DEFAULT` set globally before
+you launch tmux, and you don't have a base16-tmux theme set, it will
+default to the theme you've set in that variable. Add it to your
+shell `.*rc` file, for example:
+
+```shell
+export $BASE16_THEME_DEFAULT="solarized-light"
+```
 
 ## Contributing
 

--- a/tmuxcolors.tmux
+++ b/tmuxcolors.tmux
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
-current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+if [ -n "$BASH_VERSION" ]; then
+	script_path=${BASH_SOURCE[0]}
+elif [ -n "$ZSH_VERSION" ]; then
+	script_path=${(%):-%x}
+fi
+current_dir=${script_path%/*}
 theme_option="@colors-base16"
 default_theme="default-dark"
 
@@ -22,5 +27,6 @@ main() {
 main
 
 unset current_dir
+unset script_path
 unset theme_option
 unset default_theme

--- a/tmuxcolors.tmux
+++ b/tmuxcolors.tmux
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
+current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 theme_option="@colors-base16"
 default_theme="default-dark"
 
@@ -18,6 +17,10 @@ get_tmux_option() {
 
 main() {
 	local theme="$(get_tmux_option "$theme_option" "$default_theme")"
-	tmux source-file "$CURRENT_DIR/colors/base16-${theme}.conf"
+	tmux source-file "$current_dir/colors/base16-${theme}.conf"
 }
 main
+
+unset current_dir
+unset theme_option
+unset default_theme

--- a/tmuxcolors.tmux
+++ b/tmuxcolors.tmux
@@ -7,7 +7,7 @@ elif [ -n "$ZSH_VERSION" ]; then
 fi
 current_dir=${script_path%/*}
 theme_option="@colors-base16"
-default_theme="default-dark"
+default_theme=${BASE16_THEME_DEFAULT:-"default-dark"}
 
 get_tmux_option() {
 	local option="$1"


### PR DESCRIPTION
- Some small tweaks to the script, the biggest change is with `$current_dir` now making use of string manipulation vs `cd`, `dirname` and `pwd`. Previously we [used the same method](https://github.com/base16-project/base16-shell/commit/1ed884553b475e44eb5a4f98ab48c98636da5559#diff-5c6fe11014903a02c16a87e99eb99fef9c7c276f2111cf9657296f84d871cfdeL7) to get the `$current_dir` in base16-shell since then it's been updated.
- When you have time could you help to test the third commit? `Add support for $BASE16_THEME_DEFAULT`. I wasn't able to get it working. It may be that global environment variables don't exist in the context of the tmux script execution so it's not easily possible to have this functionality. I've had issues trying to get global env vars to be read when sourcing `.tmux.conf` so I know it can be a bit picky with the way it handles them. If this is the case, I will just remove that third commit and update the PR. Due to this "uncertain" commit I'll create a draft PR.

And more of a meta question: how do you test a plugin like this? I noticed `echo` doesn't print anything visually so to debug I was running the file through bash to make sure values looked correct.