### PR TITLE
Rename organization from base16-project to tinted-theming

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @base16-project/tmux
+* @tinted-theming/tmux

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,7 @@ about: Create a report to help us improve
 title: "[Bug report] "
 labels: ["bug"]
 assignees: 
-  - base16-project/tmux
+  - tinted-theming/tmux
 ---
 
 ## Describe the bug

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,7 @@ about: Suggest an idea for this project
 title: "[Feature request] "
 labels: ["feature"]
 assignees: 
-  - base16-project/tmux
+  - tinted-theming/tmux
 ---
 
 ## Is your feature request related to a problem? Please describe.

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,4 +1,4 @@
-name: Update with the latest base16-project/base16-schemes
+name: Update with the latest colorschemes
 on:
   workflow_dispatch:
   schedule:
@@ -16,18 +16,18 @@ jobs:
       - name: Fetch the schemes repository
         uses: actions/checkout@v3
         with:
-          repository: base16-project/base16-schemes
+          repository: tinted-theming/base16-schemes
           path: schemes
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
 
       - name: Update schemes
-        uses: base16-project/base16-builder-go@latest
+        uses: tinted-theming/base16-builder-go@latest
 
       - name: Commit the changes, if any
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: Update with the latest base16-project colorschemes
+          commit_message: Update with the latest tinted-theming colorschemes
           branch: ${{ github.head_ref }}
-          commit_user_name: base16-project-bot
-          commit_user_email: base16themeproject@proton.me
-          commit_author: base16-project-bot <base16themeproject@proton.me>
+          commit_user_name: tinted-theming-bot
+          commit_user_email: tintedtheming@proton.me
+          commit_author: tinted-theming-bot <tintedtheming@proton.me>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Or the above steps represented in shell commands:
 
 ```shell 
 cd /path/to/base16-tmux/../ # This repos parent dir 
-git clone git@github.com:base16-project/base16-builder-go.git
+git clone git@github.com:tinted-theming/base16-builder-go.git
 cd base16-builder-go
 go build ./base16-builder-go/base16-builder-go \
   -template-dir ../base16-tmux
@@ -59,8 +59,8 @@ Please follow the instructions in the issue templates:
 - [Issue template for bug reports][5]
 - [Issue template for feature requests][6]
 
-[1]: https://github.com/base16-project/base16-builder-go
-[2]: https://github.com/base16-project/base16-schemes
+[1]: https://github.com/tinted-theming/base16-builder-go
+[2]: https://github.com/tinted-theming/base16-schemes
 [3]: .github/workflows/update.yml
 [4]: .github/pull_request_template.md
 [5]: .github/ISSUE_TEMPLATE/bug_report.md

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2018 Matt Davis
+Copyright (c) 2022 [Tinted Theming](https://github.com/tinted-theming)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ not working.
 Add plugin to the list of TPM plugins in `.tmux.conf`:
 
 ```tmux
-set -g @plugin 'base16-project/base16-tmux'
+set -g @plugin 'tinted-theming/base16-tmux'
 ```
 
 Make sure to source your newly updated `.tmux.conf`. Hit `prefix + I` to
@@ -53,10 +53,10 @@ instructions.
 
 Based on the work of [tmux-colors-solarized][5].
 
-[1]: https://github.com/base16-project/home
+[1]: https://github.com/tinted-theming/home
 [2]: https://github.com/tmux-plugins/tpm
-[3]: https://github.com/base16-project/base16-shell
-[4]: https://github.com/base16-project/base16-vim
+[3]: https://github.com/tinted-theming/base16-shell
+[4]: https://github.com/tinted-theming/base16-vim
 [5]: https://github.com/seebi/tmux-colors-solarized
-[6]: https://github.com/base16-project/base16-fzf
+[6]: https://github.com/tinted-theming/base16-fzf
 [7]: CONTRIBUTING.md

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -1,4 +1,6 @@
-# COLOUR (base16)
+# Base16 {{scheme-name}}
+# Scheme author: {{scheme-author}}
+# Template author: Tinted Theming: (https://github.com/tinted-theming)
 
 # default statusbar colors
 set-option -g status-style "fg=#{{base04-hex}},bg=#{{base01-hex}}"


### PR DESCRIPTION
Base16-project had announced that it was [going to change their name in July](https://github.com/tinted-theming/home/issues/51). [After a bit of effort](https://github.com/tinted-theming/home/issues/38), we've finally renamed the organization.

This PR updates references to base16-project and also updates the license.