### PR TITLE
Adjust styling and add optional active/inactive state styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,20 @@ shell `.*rc` file, for example:
 export $BASE16_THEME_DEFAULT="solarized-light"
 ```
 
+## Configuration
+
+You can optionally enable some styling options. You can do this by
+adding the relevant environment variable to your shell `.*rc` file.
+
+### Active/inactive pane state
+
+```shell
+export BASE16_TMUX_OPTION_ACTIVE=1
+```
+
+This adds support which changes background color for the focussed pane
+vs blurred panes.
+
 ## Contributing
 
 See [`CONTRIBUTING.md`][7], which contains building and contributing

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -3,30 +3,38 @@
 # Template author: Tinted Theming: (https://github.com/tinted-theming)
 
 # default statusbar colors
-set-option -g status-style "fg=#{{base04-hex}},bg=#{{base01-hex}}"
+set-option -g status-style "fg=#{{base01-hex}},bg=#{{base01-hex}}"
 
 # default window title colors
-set-window-option -g window-status-style "fg=#{{base04-hex}},bg=default"
+set-window-option -g window-status-style "fg=#{{base01-hex}},bg=#{{base0A-hex}}"
 
 # active window title colors
-set-window-option -g window-status-current-style "fg=#{{base0A-hex}},bg=default"
+set-window-option -g window-status-current-style "fg=#{{base01-hex}},bg=#{{base09-hex}}"
 
 # pane border
 set-option -g pane-border-style "fg=#{{base01-hex}}"
-set-option -g pane-active-border-style "fg=#{{base02-hex}}"
+set-option -g pane-active-border-style "fg=#{{base04-hex}}"
 
 # message text
-set-option -g message-style "fg=#{{base05-hex}},bg=#{{base01-hex}}"
+set-option -g message-style "fg=#{{base06-hex}},bg=#{{base02-hex}}"
 
 # pane number display
-set-option -g display-panes-active-colour "#{{base0B-hex}}"
-set-option -g display-panes-colour "#{{base0A-hex}}"
+set-option -g display-panes-active-colour "#{{base04-hex}}"
+set-option -g display-panes-colour "#{{base01-hex}}"
 
 # clock
-set-window-option -g clock-mode-colour "#{{base0B-hex}}"
+set-window-option -g clock-mode-colour "#{{base0D-hex}}"
 
-# copy mode highligh
+# copy mode highlight
 set-window-option -g mode-style "fg=#{{base04-hex}},bg=#{{base02-hex}}"
 
 # bell
-set-window-option -g window-status-bell-style "fg=#{{base01-hex}},bg=#{{base08-hex}}"
+set-window-option -g window-status-bell-style "fg=#{{base00-hex}},bg=#{{base08-hex}}"
+
+# style for window titles with activity
+set-window-option -g window-status-activity-style "fg=#{{base05-hex}},bg=#{{base01-hex}}"
+
+# style for command messages
+set-option -g message-command-style "fg=#{{base06-hex}},bg=#{{base02-hex}}"
+
+# vim: set ft=tmux tw=0:

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -37,4 +37,10 @@ set-window-option -g window-status-activity-style "fg=#{{base05-hex}},bg=#{{base
 # style for command messages
 set-option -g message-command-style "fg=#{{base06-hex}},bg=#{{base02-hex}}"
 
+# Optional active/inactive pane state
+if-shell '[ "$BASE16_TMUX_OPTION_ACTIVE" = "1" ]' {
+  set-window-option -g window-active-style "fg=#{{base05-hex}},bg=#{{base00-hex}}"
+  set-window-option -g window-style "fg=#{{base05-hex}},bg=#{{base01-hex}}"
+}
+
 # vim: set ft=tmux tw=0:


### PR DESCRIPTION
I saw [this PR](https://github.com/tinted-theming/base16-tmux/pull/7) and thought it would be nice to have the active/inactive pane state styling. I slightly adjusted the colors and added the active/inactive pane state styles behind an environment variable flag since people may not want it.

This PR adds:
- Adjusts styling slightly
- Adds some new styles
- Adds new optional inactive/active pane state styles

Requires `export BASE16_TMUX_OPTION_ACTIVE=1` in `.*rc` file before tmux is lauched.