### PR TITLE
Add support for optional statusbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ export BASE16_TMUX_OPTION_ACTIVE=1
 This adds support which changes background color for the focussed pane
 vs blurred panes.
 
+### Statusbar
+
+```shell
+export BASE16_TMUX_OPTION_STATUSBAR=1
+```
+
+This adds a basic statusbar. This is optional because users may already
+have a statusbar they prefer. This statusbar was inspired by
+[tmux-gruvbox].
+
 ## Contributing
 
 See [`CONTRIBUTING.md`][7], which contains building and contributing
@@ -89,3 +99,4 @@ Based on the work of [tmux-colors-solarized][5].
 [5]: https://github.com/seebi/tmux-colors-solarized
 [6]: https://github.com/tinted-theming/base16-fzf
 [7]: CONTRIBUTING.md
+[tmux-gruvbox]: https://github.com/egel/tmux-gruvbox

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -43,4 +43,19 @@ if-shell '[ "$BASE16_TMUX_OPTION_ACTIVE" = "1" ]' {
   set-window-option -g window-style "fg=#{{base05-hex}},bg=#{{base01-hex}}"
 }
 
+# Optional statusbar
+if-shell '[ "$BASE16_TMUX_OPTION_STATUS" = "1" ]' {
+  set-option -g status "on"
+  set-option -g status-justify "left" 
+  set-option -g status-left "#[fg=#{{base05-hex}},bg=#{{base03-hex}}] #S #[fg=#{{base03-hex}},bg=#{{base01-hex}},nobold,noitalics,nounderscore]"
+  set-option -g status-left-length "80"
+  set-option -g status-left-style none
+  set-option -g status-right "#[fg=#{{base02-hex}},bg=#{{base01-hex}} nobold, nounderscore, noitalics]#[fg=#{{base04-hex}},bg=#{{base02-hex}}] %Y-%m-%d  %H:%M #[fg=#{{base05-hex}},bg=#{{base02-hex}},nobold,noitalics,nounderscore]#[fg=#{{base01-hex}},bg=#{{base05-hex}}] #h "
+  set-option -g status-right-length "80"
+  set-option -g status-right-style none
+  set-window-option -g window-status-current-format "#[fg=#{{base01-hex}},bg=#{{base0A-hex}},nobold,noitalics,nounderscore]#[fg=#{{base02-hex}},bg=#{{base0A-hex}}] #I #[fg=#{{base02-hex}},bg=#{{base0A-hex}},bold] #W#{{?window_zoomed_flag,*Z,}} #[fg=#{{base0A-hex}},bg=#{{base01-hex}},nobold,noitalics,nounderscore]"
+  set-window-option -g window-status-format "#[fg=#{{base01-hex}},bg=#{{base02-hex}},noitalics]#[fg=#{{base06-hex}},bg=#{{base02-hex}}] #I #[fg=#{{base06-hex}},bg=#{{base02-hex}}] #W #[fg=#{{base02-hex}},bg=#{{base01-hex}},noitalics]"
+  set-window-option -g window-status-separator ""
+}
+
 # vim: set ft=tmux tw=0:


### PR DESCRIPTION
Add support for nicer default statusbar styling. Optional feature and requires `export BASE16_TMUX_OPTION_STATUSBAR=1` in your `.*rc` file before tmux is launched.

![image](https://github.com/tinted-theming/base16-tmux/assets/602472/58db348d-d4c9-44c9-a4cf-1e5fb7c98525)
