### PR TITLE
Add .gitattributes to ignore generated files in PR

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+colors/* linguist-generated


### PR DESCRIPTION
Adding a `.gitattributes` as per [Github docs](https://github.com/github-linguist/linguist/blob/master/docs/overrides.md#generated-code) to ignore the `colors/*` files by default in a PR - hopefully avoiding some noise when they're regenerated.