### PR TITLE
Fix statusbar foreground color

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -3,7 +3,7 @@
 # Template author: Tinted Theming: (https://github.com/tinted-theming)
 
 # default statusbar colors
-set-option -g status-style "fg=#{{base01-hex}},bg=#{{base01-hex}}"
+set-option -g status-style "fg=#{{base04-hex}},bg=#{{base01-hex}}"
 
 # default window title colors
 set-window-option -g window-status-style "fg=#{{base01-hex}},bg=#{{base0A-hex}}"


### PR DESCRIPTION
This addresses the bug where the statusbar foreground has the same color as the background: https://github.com/tinted-theming/base16-tmux/issues/17

Previously:
![image](https://github.com/tinted-theming/base16-tmux/assets/602472/211f58b3-d5c3-4576-a6d0-870b4eec9aee)

Fix:

![image](https://github.com/tinted-theming/base16-tmux/assets/602472/37e59f39-1501-4d51-a97c-d32ca4c08216)
