### PR TITLE
Fix bug where background and foreground are switched

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -6,10 +6,10 @@
 set-option -g status-style "fg=#{{base04-hex}},bg=#{{base01-hex}}"
 
 # default window title colors
-set-window-option -g window-status-style "fg=#{{base01-hex}},bg=#{{base0A-hex}}"
+set-window-option -g window-status-style "fg=#{{base04-hex}},bg=#{{base01-hex}}"
 
 # active window title colors
-set-window-option -g window-status-current-style "fg=#{{base01-hex}},bg=#{{base09-hex}}"
+set-window-option -g window-status-current-style "fg=#{{base0A-hex}},bg=#{{base01-hex}}"
 
 # pane border
 set-option -g pane-border-style "fg=#{{base01-hex}}"


### PR DESCRIPTION
Fix bug where foreground is dark and background is colourful. This change switches it back https://github.com/tinted-theming/base16-tmux/issues/20

## Old:
![image](https://github.com/tinted-theming/base16-tmux/assets/602472/bcb795f6-7e34-42d9-87b9-5fab61174a3d)

## New:
![image](https://github.com/tinted-theming/base16-tmux/assets/602472/596dab51-0cd9-441a-8256-be294556a4ed)
