### PR TITLE
chore: remove trailing whitespace from templates

### DIFF
--- a/templates/base16.mustache
+++ b/templates/base16.mustache
@@ -48,7 +48,7 @@ if-shell '[ "$TINTED_TMUX_OPTION_ACTIVE" = "1" ] || [ "$BASE16_TMUX_OPTION_ACTIV
 # BASE16_TMUX_OPTION_STATUSBAR is a legacy variable
 if-shell '[ "$TINTED_TMUX_OPTION_STATUSBAR" = "1" ] || [ "$BASE16_TMUX_OPTION_STATUSBAR" = "1" ]' {
   set-option -g status "on"
-  set-option -g status-justify "left" 
+  set-option -g status-justify "left"
   set-option -g status-left "#[fg=#{{base05-hex}},bg=#{{base03-hex}}] #S #[fg=#{{base03-hex}},bg=#{{base01-hex}},nobold,noitalics,nounderscore]"
   set-option -g status-left-length "80"
   set-option -g status-left-style none

--- a/templates/base24.mustache
+++ b/templates/base24.mustache
@@ -46,7 +46,7 @@ if-shell '[ "$TINTED_TMUX_OPTION_ACTIVE" = "1" ]' {
 # Optional statusbar
 if-shell '[ "$TINTED_TMUX_OPTION_STATUSBAR" = "1" ]' {
   set-option -g status "on"
-  set-option -g status-justify "left" 
+  set-option -g status-justify "left"
   set-option -g status-left "#[fg=#{{base05-hex}},bg=#{{base03-hex}}] #S #[fg=#{{base03-hex}},bg=#{{base01-hex}},nobold,noitalics,nounderscore]"
   set-option -g status-left-length "80"
   set-option -g status-left-style none


### PR DESCRIPTION
This is a cosmetic thing only, but there is trailing whitespace on this line and tools like Git show it in an annoying bright color. Let's remove it:

![red highlight](https://github.com/user-attachments/assets/9d1a0e27-8c72-4803-9f93-1c6a0c5bf80d)
